### PR TITLE
Consistent naming around BTS Digital and Telstra Enterprise

### DIFF
--- a/src/App/__snapshots__/App.test.js.snap
+++ b/src/App/__snapshots__/App.test.js.snap
@@ -1149,7 +1149,7 @@ exports[`Renders bts 1`] = `
                                             }
                                           }
                                         >
-                                          Business Technology Services (Digital)
+                                          Business Technology Services - Digital
                                           <br />
                                           Telstra Enterprise
                                         </p>
@@ -1349,9 +1349,9 @@ exports[`Renders bts 1`] = `
                                         Job Title
                                       </span>
                                       <br />
-                                      Business Technology Services
+                                      Business Technology Services - Digital
                                        | 
-                                      Telstra Enterprise Services
+                                      Telstra Enterprise
                                     </p>
                                   </td>
                                 </tr>

--- a/src/BtsRepliesAndForwards/__snapshots__/BtsRepliesAndForwards.test.js.snap
+++ b/src/BtsRepliesAndForwards/__snapshots__/BtsRepliesAndForwards.test.js.snap
@@ -52,9 +52,9 @@ exports[`Renders 1`] = `
             Job Title
           </span>
           <br />
-          Business Technology Services
+          Business Technology Services - Digital
            | 
-          Telstra Enterprise Services
+          Telstra Enterprise
         </p>
       </td>
     </tr>

--- a/src/BtsSignature/BtsSignature.js
+++ b/src/BtsSignature/BtsSignature.js
@@ -201,7 +201,7 @@ const BtsSignature = props => {
                     lineHeight: '14px'
                   }}
                 >
-                  Business Technology Services (Digital)
+                  Business Technology Services - Digital
                   <br />
                   Telstra Enterprise
                 </p>

--- a/src/BtsSignature/__snapshots__/BtsSignature.test.js.snap
+++ b/src/BtsSignature/__snapshots__/BtsSignature.test.js.snap
@@ -423,7 +423,7 @@ exports[`Renders 1`] = `
                 }
               }
             >
-              Business Technology Services (Digital)
+              Business Technology Services - Digital
               <br />
               Telstra Enterprise
             </p>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -24,8 +24,8 @@ export const readify = {
 
 export const btsDigital = {
   brandInfo: {
-    brandName: 'Business Technology Services',
-    brandSecondaryText: 'Telstra Enterprise Services',
+    brandName: 'Business Technology Services - Digital',
+    brandSecondaryText: 'Telstra Enterprise',
     brandLink: 'https://www.telstra.com.au/business-enterprise',
     brandLinkName: 'www.telstra.com.au/business-enterprise',
     brandImages: {


### PR DESCRIPTION
Use consistent names between the full signature and the reply signature for BTS Digital, and Telstra Enterprise