### PR TITLE
Fix lower breakpoints

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -14,16 +14,10 @@ const App = () => (
       }}
     />
     <section className="section">
-      <div className="columns">
-        <div className="column" />
-        <div className="column is-three-quarters">
-          <div className="container">
-            <Info />
-            <Form />
-          </div>
+        <div className="container">
+          <Info />
+          <Form />
         </div>
-        <div className="column" />
-      </div>
     </section>
   </div>
 );


### PR DESCRIPTION
The presence of a fixed width `.container` inside `.column` divs with relative sizing was causing overflow at lower screen breakpoints.  Removed superfluous elements to resolve this.

## Before

![before](https://user-images.githubusercontent.com/6289998/55365231-79650c00-552f-11e9-9e16-9340ed01f718.PNG)

## After

![after](https://user-images.githubusercontent.com/6289998/55365236-7ec25680-552f-11e9-8826-da9f1f19ebda.PNG)